### PR TITLE
fix: edit async args

### DIFF
--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -245,7 +245,10 @@ function M.run_async(method_name, args, callback)
     local mod = require("kubectl_client")
     local ok, result = pcall(mod[method], json_str)
     if not ok then
-      return nil, result
+      return nil, tostring(result)
+    end
+    if type(result) ~= "string" then
+      return tostring(result), nil
     end
     return result, nil
   end

--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -274,7 +274,7 @@ function M.get_mappings()
               group = group,
               callback = function()
                 commands.run_async("edit_async", {
-                  tmpfilename,
+                  path = tmpfilename,
                 }, function(result, err)
                   vim.schedule(function()
                     if err then


### PR DESCRIPTION
Summary

Fixes resource edit (ge) failing on save/quit with an opaque userdata: 0x... notification instead of a real success or error message.

• Pass { path = tmpfilename } to edit_async so the Rust client receives {"path":"..."} instead of a JSON array
• Stringify errors (and non-string results) in run_async's vim.uv.new_work callback before returning to the main thread, so vim.notify shows the actual message

Problem

On :wq after editing a resource, users saw notifications like:

16:17:15 │ userdata: 0x01557783a0

The editor opened correctly (get_single_async uses the right payload shape), but the apply step never worked. edit_async expected CmdEditArgs { path } while Lua sent { tmpfilename }, which encodes as
["/tmp/..."]. Deserialization failed, and the mlua error lost its __tostring when crossing the worker thread boundary.