### PR TITLE
fix: no mappings on action float

### DIFF
--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -645,6 +645,7 @@ end
 function M.register()
   local win_id = vim.api.nvim_get_current_win()
   local win_config = vim.api.nvim_win_get_config(win_id)
+  local is_action = vim.bo.filetype == "k8s_action"
   -- Global mappings
   if win_config.relative == "" then
     M.map_if_plug_not_set("n", "1", "<Plug>(kubectl.view_deployments)")
@@ -666,6 +667,10 @@ function M.register()
     vim.api.nvim_buf_set_keymap(0, "n", "<esc>", "<Plug>(kubectl.quit)", opts)
     vim.api.nvim_buf_set_keymap(0, "i", "<C-c>", "<Esc><Plug>(kubectl.quit)", opts)
     vim.api.nvim_buf_set_keymap(0, "n", "<f4>", "<Plug>(kubectl.toggle_fullscreen)", opts)
+  end
+
+  if is_action then
+    return
   end
 
   M.map_if_plug_not_set("n", "<Tab>", "<Plug>(kubectl.tab)")


### PR DESCRIPTION
## Preserve native Vim keybindings in editable action floats
### Problem
When an editable action float is open (e.g. `gss` to scale a deployment, which opens a float to input the replica count), the plugin's resource-view keymaps remain active as buffer-local mappings.
This hijacks native Vim editing keys — most notably `<C-x>` (mapped to the contexts view) and `<C-a>` (mapped to the aliases view), which normally decrement/increment integers under the cursor.
As a result, you can't use `<C-a>`/`<C-x>` to adjust the number in the scale input.
### Root cause
`M.register()` in `lua/kubectl/mappings.lua` applies the resource-view mapping block (`<C-x>`, `<C-a>`, `<C-f>`, `<C-n>`, `<cr>`, etc.) unconditionally to every `k8s_*` buffer, including floats.
The `FileType k8s_*` autocmd runs this for the `k8s_action` float too, clobbering native keys in an editable input buffer.
### Fix
Skip the resource-view mapping block for editable action floats (filetype `k8s_action`). These floats keep only what they need: the float-specific mappings (`q`, `<esc>`, `<C-c>`, `<f4>`), their
own `<Tab>` handler, and `y`/`n` confirmation. `k8s_action` covers all editable input floats (scale, set-image, rollout restart, delete, port-forward).
The change is intentionally scoped to `k8s_action` rather than all floats, because list-style floats (contexts, namespace, picker) have no dedicated mappings file and rely on this global block for
selection (`<cr>`) and other actions.
### Result
Native Vim behavior (`<C-a>`/`<C-x>` increment/decrement, etc.) works as expected inside editable action floats, while resource views and list floats are unaffected.